### PR TITLE
Extensible loading of entries for incremental index

### DIFF
--- a/ESales.EPiServer.Tests/PluginTests.cs
+++ b/ESales.EPiServer.Tests/PluginTests.cs
@@ -330,6 +330,7 @@ namespace ESales.EPiServer.Tests
             var builder = new ContainerBuilder();
             builder.RegisterType<ProductIndexBuilder>();
             builder.RegisterType<EntryConverter>();
+            builder.RegisterType<CatalogEntryProviderFactory>();
             builder.Register( c => catalogSystem.Object );
             builder.Register( c => metaData.Object );
             builder.Register( c => priceService.Object );

--- a/ESales.EPiServer.Tests/ProductIndexBuilderAttributeTests.cs
+++ b/ESales.EPiServer.Tests/ProductIndexBuilderAttributeTests.cs
@@ -79,6 +79,7 @@ namespace ESales.EPiServer.Tests
             builder.Register( c => priceService.Object );
             builder.Register( c => entryAdditionalData.Object );
             builder.RegisterType<EntryConverter>();
+            builder.RegisterType<CatalogEntryProviderFactory>();
             builder.Register( c => new PromotionEntryCodeProvider( c.Resolve<PromotionDataTableMapper>(), Enumerable.Empty<IPromotionEntryCodes>() ) );
             builder.Register( c => new PromotionDataTableMapper(
                                        new PromotionDto.PromotionLanguageDataTable(),

--- a/ESales.EPiServer/DataAccess/CatalogEntryProviderFactory.cs
+++ b/ESales.EPiServer/DataAccess/CatalogEntryProviderFactory.cs
@@ -1,3 +1,4 @@
+using System.Collections.Generic;
 using Apptus.ESales.EPiServer.Import.Products;
 
 namespace Apptus.ESales.EPiServer.DataAccess
@@ -6,18 +7,20 @@ namespace Apptus.ESales.EPiServer.DataAccess
     {
         private readonly ICatalogSystemMapper _catalogSystemMapper;
         private readonly IIndexSystemMapper _indexSystemMapper;
+        private readonly IEnumerable<IModifiedCatalogEntryLoader> _modifiedCatalogEntryLoaders;
 
-        public CatalogEntryProviderFactory(ICatalogSystemMapper catalogSystemMapper, IIndexSystemMapper indexSystemMapper)
+        public CatalogEntryProviderFactory(ICatalogSystemMapper catalogSystemMapper, IIndexSystemMapper indexSystemMapper, IEnumerable<IModifiedCatalogEntryLoader> modifiedCatalogEntryLoaders)
         {
             _catalogSystemMapper = catalogSystemMapper;
             _indexSystemMapper = indexSystemMapper;
+            _modifiedCatalogEntryLoaders = modifiedCatalogEntryLoaders;
         }
 
         public ICatalogEntryProvider Create(bool incremental, int catalogId, ESalesVariantHelper eSalesVariantHelper)
         {
             if (incremental)
             {
-                return new IncrementalCatalogEntryProvider(catalogId, eSalesVariantHelper, _catalogSystemMapper, _indexSystemMapper);
+                return new IncrementalCatalogEntryProvider(catalogId, eSalesVariantHelper, _catalogSystemMapper, _indexSystemMapper, _modifiedCatalogEntryLoaders);
             }
             return new FullCatalogEntryProvider(catalogId, _catalogSystemMapper);
         }

--- a/ESales.EPiServer/DataAccess/CatalogEntryProviderFactory.cs
+++ b/ESales.EPiServer/DataAccess/CatalogEntryProviderFactory.cs
@@ -2,17 +2,24 @@ using Apptus.ESales.EPiServer.Import.Products;
 
 namespace Apptus.ESales.EPiServer.DataAccess
 {
-    internal static class CatalogEntryProviderFactory
+    internal class CatalogEntryProviderFactory
     {
-        public static ICatalogEntryProvider Create( bool incremental, int catalogId, ESalesVariantHelper eSalesVariantHelper, ICatalogSystemMapper catalogSystemMapper,
-                                             IIndexSystemMapper indexSystemMapper )
+        private readonly ICatalogSystemMapper _catalogSystemMapper;
+        private readonly IIndexSystemMapper _indexSystemMapper;
 
+        public CatalogEntryProviderFactory(ICatalogSystemMapper catalogSystemMapper, IIndexSystemMapper indexSystemMapper)
         {
-            if ( incremental )
+            _catalogSystemMapper = catalogSystemMapper;
+            _indexSystemMapper = indexSystemMapper;
+        }
+
+        public ICatalogEntryProvider Create(bool incremental, int catalogId, ESalesVariantHelper eSalesVariantHelper)
+        {
+            if (incremental)
             {
-                return new IncrementalCatalogEntryProvider( catalogId, eSalesVariantHelper, catalogSystemMapper, indexSystemMapper );
+                return new IncrementalCatalogEntryProvider(catalogId, eSalesVariantHelper, _catalogSystemMapper, _indexSystemMapper);
             }
-            return new FullCatalogEntryProvider( catalogId, catalogSystemMapper );
+            return new FullCatalogEntryProvider(catalogId, _catalogSystemMapper);
         }
     }
 }

--- a/ESales.EPiServer/DataAccess/DefaultModifiedCatalogEntryLoader.cs
+++ b/ESales.EPiServer/DataAccess/DefaultModifiedCatalogEntryLoader.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Mediachase.Commerce.Catalog.Dto;
+
+namespace Apptus.ESales.EPiServer.DataAccess
+{
+    internal class DefaultModifiedCatalogEntryLoader : IModifiedCatalogEntryLoader
+    {
+        private readonly ICatalogSystemMapper _catalogSystemMapper;
+
+        public DefaultModifiedCatalogEntryLoader(ICatalogSystemMapper catalogSystemMapper)
+        {
+            _catalogSystemMapper = catalogSystemMapper;
+        }
+
+        public IEnumerable<CatalogEntryDto.CatalogEntryRow> Load(int catalogId, DateTime earliestModifiedDate, DateTime latestModifiedDate)
+        {
+            var searchSetId = Guid.NewGuid();
+            _catalogSystemMapper.StartFindItemsForIndexing(searchSetId, catalogId, true, earliestModifiedDate, latestModifiedDate);
+            var entryTable = _catalogSystemMapper.ContinueFindItemsForIndexing(searchSetId, 1, int.MaxValue - 1);
+            return entryTable.Rows.Cast<CatalogEntryDto.CatalogEntryRow>();
+        }
+    }
+}

--- a/ESales.EPiServer/DataAccess/IModifiedCatalogEntryLoader.cs
+++ b/ESales.EPiServer/DataAccess/IModifiedCatalogEntryLoader.cs
@@ -1,0 +1,11 @@
+﻿using System;
+using System.Collections.Generic;
+using Mediachase.Commerce.Catalog.Dto;
+
+namespace Apptus.ESales.EPiServer.DataAccess
+{
+    public interface IModifiedCatalogEntryLoader
+    {
+        IEnumerable<CatalogEntryDto.CatalogEntryRow> Load(int catalogId, DateTime earliestModifiedDate, DateTime latestModifiedDate);
+    }
+}

--- a/ESales.EPiServer/DataAccess/IncrementalCatalogEntryProvider.cs
+++ b/ESales.EPiServer/DataAccess/IncrementalCatalogEntryProvider.cs
@@ -1,9 +1,8 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Apptus.ESales.EPiServer.Import.Products;
+using Apptus.ESales.EPiServer.Util;
 using Mediachase.Commerce.Catalog.Dto;
-using Mediachase.Commerce.Catalog.Managers;
 
 namespace Apptus.ESales.EPiServer.DataAccess
 {
@@ -13,18 +12,22 @@ namespace Apptus.ESales.EPiServer.DataAccess
         private readonly ICatalogSystemMapper _catalogSystemMapper;
         private readonly CatalogEntryDto.CatalogEntryRow[] _allEntries;
 
-        internal IncrementalCatalogEntryProvider( int catalogId, ESalesVariantHelper eSalesVariantHelper, ICatalogSystemMapper catalogSystemMapper,
-                                                  IIndexSystemMapper indexSystemMapper )
+        internal IncrementalCatalogEntryProvider(
+            int catalogId, ESalesVariantHelper eSalesVariantHelper, ICatalogSystemMapper catalogSystemMapper,
+            IIndexSystemMapper indexSystemMapper, IEnumerable<IModifiedCatalogEntryLoader> modifiedCatalogEntryLoaders)
         {
             _eSalesVariantHelper = eSalesVariantHelper;
             _catalogSystemMapper = catalogSystemMapper;
-            
-            var searchSetId = Guid.NewGuid();
-            _catalogSystemMapper.StartFindItemsForIndexing( searchSetId, catalogId, true, indexSystemMapper.LastBuildDate.ToUniversalTime(),
-                                                            indexSystemMapper.CurrentBuildDate );
-            var entryTable = _catalogSystemMapper.ContinueFindItemsForIndexing( searchSetId, 1, int.MaxValue - 1 );
-            var originalEntries = entryTable.Rows.Cast<CatalogEntryDto.CatalogEntryRow>().ToDictionary( e => e.CatalogEntryId, e => e );
-            _allEntries = AppendMissingVariants( originalEntries ).ToArray();
+
+            var earliestModifiedDate = indexSystemMapper.LastBuildDate.ToUniversalTime();
+            var latestModifiedDate = indexSystemMapper.CurrentBuildDate;
+
+            var catalogEntryRows = modifiedCatalogEntryLoaders
+                .SelectMany(loader => loader.Load(catalogId, earliestModifiedDate, latestModifiedDate))
+                .Distinct(entry => entry.CatalogEntryId);
+
+            var originalEntries = catalogEntryRows.ToDictionary(e => e.CatalogEntryId, e => e);
+            _allEntries = AppendMissingVariants(originalEntries).ToArray();
         }
 
         public int Count

--- a/ESales.EPiServer/ESales.EPiServer.csproj
+++ b/ESales.EPiServer/ESales.EPiServer.csproj
@@ -116,6 +116,8 @@
     <Compile Include="DataAccess\CatalogEntryProviderFactory.cs" />
     <Compile Include="DataAccess\CatalogEntryRowMapper.cs" />
     <Compile Include="DataAccess\CatalogSystemMapper.cs" />
+    <Compile Include="DataAccess\DefaultModifiedCatalogEntryLoader.cs" />
+    <Compile Include="DataAccess\IModifiedCatalogEntryLoader.cs" />
     <Compile Include="DataAccess\CodeKeyLookup.cs" />
     <Compile Include="DataAccess\ConnectorHelper.cs" />
     <Compile Include="DataAccess\ConnectorMapper.cs" />
@@ -239,6 +241,8 @@
     <Compile Include="Navigation\ESalesMenuProvider.cs" />
     <Compile Include="Util\ArgumentHelper.cs" />
     <Compile Include="Util\AssemblyProvider.cs" />
+    <Compile Include="Util\EnumerableExtensions.cs" />
+    <Compile Include="Util\ValueEqualityComparer.cs" />
     <Compile Include="Util\Extensions.cs" />
     <Compile Include="Util\ESales.cs" />
     <Compile Include="Util\ESalesEntry.cs" />

--- a/ESales.EPiServer/Import/ESalesCatalogIndexBuilder.cs
+++ b/ESales.EPiServer/Import/ESalesCatalogIndexBuilder.cs
@@ -138,14 +138,15 @@ namespace Apptus.ESales.EPiServer.Import
             }
         }
 
-        private static void RegisterPlugins( ContainerBuilder builder )
+        private static void RegisterPlugins(ContainerBuilder builder)
         {
             var assemblies = AssemblyProvider.GetAssemblies().ToArray();
-            builder.RegisterAssemblyTypes( assemblies ).As<IPromotionEntryCodes>().InstancePerLifetimeScope();
-            builder.RegisterAssemblyTypes( assemblies ).As<IProductConverter>().InstancePerLifetimeScope();
-            builder.RegisterAssemblyTypes( assemblies ).As<IAdConverter>().InstancePerLifetimeScope();
-            builder.RegisterAssemblyTypes( assemblies ).As<IProductsAppender>().InstancePerLifetimeScope();
-            builder.RegisterAssemblyTypes( assemblies ).As<IAdsAppender>().InstancePerLifetimeScope();
+            builder.RegisterAssemblyTypes(assemblies).As<IPromotionEntryCodes>().InstancePerLifetimeScope();
+            builder.RegisterAssemblyTypes(assemblies).As<IProductConverter>().InstancePerLifetimeScope();
+            builder.RegisterAssemblyTypes(assemblies).As<IAdConverter>().InstancePerLifetimeScope();
+            builder.RegisterAssemblyTypes(assemblies).As<IProductsAppender>().InstancePerLifetimeScope();
+            builder.RegisterAssemblyTypes(assemblies).As<IAdsAppender>().InstancePerLifetimeScope();
+            builder.RegisterAssemblyTypes(assemblies).As<IModifiedCatalogEntryLoader>().InstancePerLifetimeScope();
         }
     }
 }

--- a/ESales.EPiServer/Import/ESalesCatalogIndexBuilder.cs
+++ b/ESales.EPiServer/Import/ESalesCatalogIndexBuilder.cs
@@ -124,6 +124,7 @@ namespace Apptus.ESales.EPiServer.Import
             builder.RegisterType<ESalesIndexBuilder>().InstancePerLifetimeScope();
             builder.RegisterType<UrlResolver>().As<IUrlResolver>();
             builder.RegisterType<EntryAdditionalData>().As<IEntryAdditionalData>();
+            builder.RegisterType<CatalogEntryProviderFactory>();
 
             RegisterPlugins( builder );
 

--- a/ESales.EPiServer/Import/Products/ProductIndexBuilder.cs
+++ b/ESales.EPiServer/Import/Products/ProductIndexBuilder.cs
@@ -17,13 +17,15 @@ namespace Apptus.ESales.EPiServer.Import.Products
         private readonly IKeyLookup _keyLookup;
         private readonly EntryConverter _entryConverter;
         private readonly IOperationsWriter _writer;
+        private readonly CatalogEntryProviderFactory _catalogEntryProviderFactory;
         private readonly IProductConverter _converterPlugin;
         private readonly IProductsAppender _appenderPlugin;
         private Progress _progress;
 
-        public ProductIndexBuilder( IAppConfig appConfig, ICatalogSystemMapper catalogSystem, IIndexSystemMapper indexSystem, IKeyLookup keyLookup,
-                                    EntryConverter entryConverter, IOperationsWriter writer, IProductConverter converterPlugin = null,
-                                    IProductsAppender appenderPlugin = null )
+        public ProductIndexBuilder(
+            IAppConfig appConfig, ICatalogSystemMapper catalogSystem, IIndexSystemMapper indexSystem, IKeyLookup keyLookup,
+            EntryConverter entryConverter, IOperationsWriter writer, CatalogEntryProviderFactory catalogEntryProviderFactory,
+            IProductConverter converterPlugin = null, IProductsAppender appenderPlugin = null)
         {
             _appConfig = appConfig;
             _catalogSystem = catalogSystem;
@@ -31,6 +33,7 @@ namespace Apptus.ESales.EPiServer.Import.Products
             _keyLookup = keyLookup;
             _entryConverter = entryConverter;
             _writer = writer;
+            _catalogEntryProviderFactory = catalogEntryProviderFactory;
             _converterPlugin = converterPlugin;
             _appenderPlugin = appenderPlugin;
         }
@@ -77,7 +80,7 @@ namespace Apptus.ESales.EPiServer.Import.Products
         private void WriteDocuments( CatalogDto.CatalogRow catalog, string[] languages )
         {
             var variantHelper = new ESalesVariantHelper( GetRelations( catalog.CatalogId ) );
-            var catalogEntryProvider = CatalogEntryProviderFactory.Create( _incremental, catalog.CatalogId, variantHelper, _catalogSystem, _indexSystem );
+            var catalogEntryProvider = _catalogEntryProviderFactory.Create(_incremental, catalog.CatalogId, variantHelper);
             _progress.TotalNbrOfEntries = catalogEntryProvider.Count;
             var firstCatalogEntryId = int.MaxValue;
             var lastCatalogEntryId = int.MinValue;

--- a/ESales.EPiServer/Util/EnumerableExtensions.cs
+++ b/ESales.EPiServer/Util/EnumerableExtensions.cs
@@ -1,0 +1,24 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Apptus.ESales.EPiServer.Util
+{
+    public static class EnumerableExtensions
+    {
+        public static IEnumerable<T> Distinct<T, TValue>(this IEnumerable<T> source, Func<T, TValue> valueSelector)
+        {
+            if (source == null) throw new ArgumentNullException("source");
+            if (valueSelector == null) throw new ArgumentNullException("valueSelector");
+            return source.Distinct(new ValueEqualityComparer<T, TValue>(valueSelector));
+        }
+
+        public static IEnumerable<T> Distinct<T, TValue>(this IEnumerable<T> source, Func<T, TValue> valueSelector, IEqualityComparer<TValue> comparer)
+        {
+            if (source == null) throw new ArgumentNullException("source");
+            if (valueSelector == null) throw new ArgumentNullException("valueSelector");
+            if (comparer == null) throw new ArgumentNullException("comparer");
+            return source.Distinct(new ValueEqualityComparer<T, TValue>(valueSelector, comparer));
+        }
+    }
+}

--- a/ESales.EPiServer/Util/ValueEqualityComparer.cs
+++ b/ESales.EPiServer/Util/ValueEqualityComparer.cs
@@ -1,0 +1,28 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Apptus.ESales.EPiServer.Util
+{
+    public class ValueEqualityComparer<T, TValue> : IEqualityComparer<T>
+    {
+        private readonly Func<T, TValue> _valueSelector;
+        private readonly IEqualityComparer<TValue> _comparer;
+
+        public ValueEqualityComparer(Func<T, TValue> valueSelector, IEqualityComparer<TValue> comparer = null)
+        {
+            if (valueSelector == null) throw new ArgumentNullException("valueSelector");
+            _valueSelector = valueSelector;
+            _comparer = comparer ?? EqualityComparer<TValue>.Default;
+        }
+
+        public bool Equals(T x, T y)
+        {
+            return _comparer.Equals(_valueSelector(x), _valueSelector(y));
+        }
+
+        public int GetHashCode(T obj)
+        {
+            return _comparer.GetHashCode(_valueSelector(obj));
+        }
+    }
+}


### PR DESCRIPTION
IModifiedCatalogEntryLoader can be implemented to load entries that has been affected by relations and needs to be re-indexed.